### PR TITLE
rename signAndSend to signAndSendTransaction

### DIFF
--- a/src/common/validation.rs
+++ b/src/common/validation.rs
@@ -345,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_and_send_mode() {
+    fn test_sign_and_send_transaction_mode() {
         let fee_payer = Pubkey::new_unique();
         let config = ValidationConfig {
             max_allowed_lamports: 1_000_000,

--- a/src/rpc/lib.rs
+++ b/src/rpc/lib.rs
@@ -13,7 +13,9 @@ use super::method::{
     get_blockhash::{get_blockhash, GetBlockhashResponse},
     get_config::{get_config, GetConfigResponse},
     get_supported_tokens::{get_supported_tokens, GetSupportedTokensResponse},
-    sign_and_send::{sign_and_send, SignAndSendTransactionRequest, SignAndSendTransactionResult},
+    sign_and_send_transaction::{
+        sign_and_send_transaction, SignAndSendTransactionRequest, SignAndSendTransactionResult,
+    },
     sign_transaction::{sign_transaction, SignTransactionRequest, SignTransactionResult},
     sign_transaction_if_paid::{
         sign_transaction_if_paid, SignTransactionIfPaidRequest, SignTransactionIfPaidResponse,
@@ -74,13 +76,13 @@ impl KoraRpc {
         result
     }
 
-    pub async fn sign_and_send(
+    pub async fn sign_and_send_transaction(
         &self,
         request: SignAndSendTransactionRequest,
     ) -> Result<SignAndSendTransactionResult, KoraError> {
-        info!("Sign and send request: {:?}", request);
-        let result = sign_and_send(&self.rpc_client, &self.validation, request).await;
-        info!("Sign and send response: {:?}", result);
+        info!("Sign and send transaction request: {:?}", request);
+        let result = sign_and_send_transaction(&self.rpc_client, &self.validation, request).await;
+        info!("Sign and send transaction response: {:?}", result);
         result
     }
 

--- a/src/rpc/method/mod.rs
+++ b/src/rpc/method/mod.rs
@@ -2,7 +2,7 @@ pub mod estimate_transaction_fee;
 pub mod get_blockhash;
 pub mod get_config;
 pub mod get_supported_tokens;
-pub mod sign_and_send;
+pub mod sign_and_send_transaction;
 pub mod sign_transaction;
 pub mod sign_transaction_if_paid;
 pub mod transfer_transaction;

--- a/src/rpc/method/sign_and_send_transaction.rs
+++ b/src/rpc/method/sign_and_send_transaction.rs
@@ -20,7 +20,7 @@ pub struct SignAndSendTransactionResult {
     pub signed_transaction: String,
 }
 
-pub async fn sign_and_send(
+pub async fn sign_and_send_transaction(
     rpc_client: &Arc<RpcClient>,
     validation: &ValidationConfig,
     request: SignAndSendTransactionRequest,

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -68,11 +68,14 @@ fn build_rpc_module(rpc: KoraRpc) -> Result<RpcModule<KoraRpc>, anyhow::Error> {
         rpc.sign_transaction(params).await.map_err(Into::into)
     });
 
-    let _ = module.register_async_method("signAndSend", |rpc_params, rpc_context| async move {
-        let rpc = rpc_context.as_ref();
-        let params = rpc_params.parse()?;
-        rpc.sign_and_send(params).await.map_err(Into::into)
-    });
+    let _ = module.register_async_method(
+        "signAndSendTransaction",
+        |rpc_params, rpc_context| async move {
+            let rpc = rpc_context.as_ref();
+            let params = rpc_params.parse()?;
+            rpc.sign_and_send_transaction(params).await.map_err(Into::into)
+        },
+    );
 
     let _ =
         module.register_async_method("transferTransaction", |rpc_params, rpc_context| async move {

--- a/tests/api_integration_tests.rs
+++ b/tests/api_integration_tests.rs
@@ -126,11 +126,13 @@ async fn test_sign_transaction() {
 }
 
 #[tokio::test]
-async fn test_sign_and_send() {
+async fn test_sign_and_send_transaction() {
     let client = setup_test_client().await;
     let test_tx = create_test_transaction().await;
 
-    let result = client.request::<serde_json::Value, _>("signAndSend", rpc_params![test_tx]).await;
+    let result = client
+        .request::<serde_json::Value, _>("signAndSendTransaction", rpc_params![test_tx])
+        .await;
 
     // This might fail if we're not on devnet/testnet with funded accounts
     match result {
@@ -142,7 +144,10 @@ async fn test_sign_and_send() {
             );
         }
         Err(e) => {
-            println!("Note: signAndSend failed as expected without funded accounts: {}", e);
+            println!(
+                "Note: signAndSendTransaction failed as expected without funded accounts: {}",
+                e
+            );
         }
     }
 }

--- a/tests/examples/signAndSendTransaction.json
+++ b/tests/examples/signAndSendTransaction.json
@@ -1,7 +1,7 @@
 {
 	"jsonrpc": "2.0",
 	"id": 1,
-	"method": "signAndSend",
+	"method": "signAndSendTransaction",
 	"params": [
 		"3md7BBV9wFjYGnMWcMNyAZcjca2HGfXWZkrU8vvho66z2sJMZFcx6HZdBiAddjo2kzgBv3uZoac3domBRjJJSXkbBvokxSKZJ1JkQwVSYyKhcnWsgMzvEfJBaSjk7jdz8updcXb8j1Ejz1yWaZgeuV6wy4pncAFHDybqUih4TmRgcbARs5t3ZXRNTDqedyMiJUg5Jz1Apt2ohLsffqjnAhrbC41xrphouRDPx356JNz5MjKi4iLkBnRHfUMJiDxtbXCYNTe257PoASUU2v12WDYFheGKzHP8ctmN7"
 	]


### PR DESCRIPTION
## Rename signAndSend to signAndSendTransaction for Relayer Spec Compliance
This PR renames the signAndSend endpoint to signAndSendTransaction to align with the [Relayer Specification](https://docs.google.com/document/d/1lweO5WH12QJaSAu5RG_wUistyk_nFeT6gy1CdvyCEHg/edit?tab=t.0).

## Changes
* Renamed RPC endpoint from signAndSend to signAndSendTransaction
* Updated method names in code to match new endpoint name
* No functional changes to the endpoint behavior

## Testing
* Verified all existing tests pass with updated method name
* Confirmed endpoint continues to function as expected

